### PR TITLE
Upgrade PHP version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 dist: trusty
 php:
-  - '5.6'
-  - '7.0'
   - '7.1'
+  - '7.2'
+  - '7.3'
 install:
   - composer update
 script:

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "illuminate/support": "^5.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7",
+        "phpunit/phpunit": "^7.0 || ^8.0",
         "satooshi/php-coveralls": "^2.0"
     },
     "license": "LGPL-3.0-only",


### PR DESCRIPTION
# Changed log
- Remove the `php-5.6` and `php-7.0` versions because they are unsupported from official PHP team.
- Let the package require `php-7.1` version at least.
- Let the PHPUnit require `^7.0` and `^8.0` versions.